### PR TITLE
[ARC302 Well-Architected] [SEC04-BP01]: サービスとアプリケーションのログ記録の設定

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py
@@ -13,20 +13,23 @@ import logging
 import uuid
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+log_level = os.environ.get("LOG_LEVEL", "INFO")
+logger.setLevel(log_level)
 
 dynamodb_client = boto3.client("dynamodb")
 
 
 def handler(event, context):
     table = os.environ.get("TABLE_NAME")
-    logging.info(f"## Loaded table name from environemt variable DDB_TABLE: {table}")
+    logger.info(f"Processing request - RequestId: {context.request_id}")
+    
     if event["body"]:
         item = json.loads(event["body"])
-        logging.info(f"## Received payload: {item}")
         year = str(item["year"])
         title = str(item["title"])
         id = str(item["id"])
+        logger.info(f"Inserting item with id: {id}")
+        
         dynamodb_client.put_item(
             TableName=table,
             Item={"year": {"N": year}, "title": {"S": title}, "id": {"S": id}},
@@ -38,13 +41,16 @@ def handler(event, context):
             "body": json.dumps({"message": message}),
         }
     else:
-        logging.info("## Received request without a payload")
+        logger.info("Received request without payload - inserting default data")
+        default_id = str(uuid.uuid4())
+        logger.info(f"Inserting default item with id: {default_id}")
+        
         dynamodb_client.put_item(
             TableName=table,
             Item={
                 "year": {"N": "2012"},
                 "title": {"S": "The Amazing Spider-Man 2"},
-                "id": {"S": str(uuid.uuid4())},
+                "id": {"S": default_id},
             },
         )
         message = "Successfully inserted data!"

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -9,6 +9,7 @@ from aws_cdk import (
     aws_apigateway as apigw_,
     aws_ec2 as ec2,
     aws_iam as iam,
+    aws_logs as logs,
     Duration,
 )
 from constructs import Construct
@@ -65,6 +66,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             partition_key=dynamodb_.Attribute(
                 name="id", type=dynamodb_.AttributeType.STRING
             ),
+            point_in_time_recovery=True,
         )
 
         # Create the Lambda function to receive the request
@@ -82,11 +84,20 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             memory_size=1024,
             timeout=Duration.minutes(5),
             tracing=lambda_.Tracing.ACTIVE,
+            log_retention=logs.RetentionDays.ONE_YEAR,
         )
 
         # grant permission to lambda to write to demo table
         demo_table.grant_write_data(api_hanlder)
         api_hanlder.add_environment("TABLE_NAME", demo_table.table_name)
+        api_hanlder.add_environment("LOG_LEVEL", "INFO")
+
+        # Create CloudWatch Logs log group for API Gateway access logs
+        api_log_group = logs.LogGroup(
+            self,
+            "ApiGatewayAccessLogs",
+            retention=logs.RetentionDays.ONE_YEAR,
+        )
 
         # Create API Gateway
         apigw_.LambdaRestApi(
@@ -95,5 +106,17 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
                 tracing_enabled=True,
+                access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
+                access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(
+                    caller=True,
+                    http_method=True,
+                    ip=True,
+                    protocol=True,
+                    request_time=True,
+                    resource_path=True,
+                    response_length=True,
+                    status=True,
+                    user=True,
+                ),
             ),
         )


### PR DESCRIPTION
## Summary

このPRは、AWS Well-Architected Framework SEC04-BP01 (サービスとアプリケーションのログ記録の設定) に準拠するため、包括的なログ記録とデータ保護機能を実装します。API Gatewayアクセスログ、Lambda関数のログ保持期間、DynamoDB Point-in-Time Recovery (PITR)を設定し、セキュリティイベントの監査と調査に必要なログ基盤を確立します。

Fixes #2

## Changes Made

### API Gatewayアクセスログの有効化
- CloudWatch Logsロググループを作成し、1年間の保持期間を設定
- API Gatewayの`deploy_options`に`access_log_destination`と`access_log_format`を設定
- JSON形式で標準フィールド(caller, http_method, ip, protocol, request_time, resource_path, response_length, status, user)を記録
- APIへのすべてのアクセス履歴とリクエスト/レスポンス詳細を追跡可能に

### Lambda関数のログ保持期間設定
- `log_retention=logs.RetentionDays.ONE_YEAR`を追加
- CloudWatch Logsロググループの保持期間を1年に設定し、コスト最適化とデータガバナンスを実現
- `aws_logs`モジュールをインポートに追加

### DynamoDB Point-in-Time Recovery (PITR)の有効化
- `point_in_time_recovery=True`をDynamoDBテーブル定義に追加
- 過去35日間のデータ変更履歴を追跡可能に
- セキュリティインシデント調査時の根本原因分析をサポート

### Lambda関数のログレベル環境変数制御
- ログレベルを環境変数`LOG_LEVEL`から取得するように変更
- CDKスタックで`LOG_LEVEL`環境変数を設定
- 機密データ全体のログ記録を削減し、監査に必要な情報(RequestId、操作タイプ、ID)のみを記録
- セキュリティベストプラクティスに準拠したログ記録を実装

## Well-Architected Framework Compliance

これらの変更により、SEC04-BP01のベストプラクティスに準拠し、セキュリティイベントの検出と調査能力が大幅に向上します。適切なログ記録がない場合、セキュリティインシデント発生時の根本原因分析が困難になり、コンプライアンス要件を満たせないリスクがあります。

✅ **セキュリティ監査の実現**: API Gatewayアクセスログにより、誰がいつAPIにアクセスしたかを完全に追跡
✅ **コンプライアンス対応**: 1年間のログ保持により、規制要件とガバナンス義務を満たす
✅ **インシデント対応の迅速化**: DynamoDB PITRにより、過去35日間のデータ状態を復元し、セキュリティ侵害の範囲とタイムラインを特定
✅ **コスト最適化**: 明示的なログ保持期間設定により、無期限保持によるコスト増加を防止
✅ **データ保護**: 機密データの完全なログ記録を避け、監査に必要な情報のみを記録

## Testing

デプロイ後、以下の手順でログ記録設定を確認できます:

1. **API Gatewayアクセスログ**: CloudWatch Logsコンソールで`ApiGatewayAccessLogs`ロググループを確認し、APIリクエストのJSON形式ログが記録されていることを確認
2. **Lambda関数ログ保持期間**: CloudWatch Logsコンソールで`/aws/lambda/apigw_handler`ロググループの保持期間が1年に設定されていることを確認
3. **DynamoDB PITR**: DynamoDBコンソールでテーブルの「バックアップ」タブを確認し、PITRが有効化されていることを確認
4. **ログレベル制御**: Lambda関数の環境変数`LOG_LEVEL`を変更し、ログ出力が動的に制御されることを確認

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - API Gatewayアクセスログ、Lambda関数ログ保持期間、DynamoDB PITRを設定
- `python/apigw-http-api-lambda-dynamodb-python-cdk/lambda/apigw-handler/index.py` - 環境変数ベースのログレベル制御と機密データログ記録の削減を実装